### PR TITLE
Fix reading from public Azure blobs without authentication

### DIFF
--- a/neuron-viewer/python/server.py
+++ b/neuron-viewer/python/server.py
@@ -7,10 +7,15 @@ from flask_cors import CORS
 import blobfile as bf
 import json
 
-def load_az_json(path):
-    with bf.BlobFile(path) as f:
-        return json.load(f)
+import urllib.request
 
+def load_az_json(url):
+    try:
+        with urllib.request.urlopen(url) as f:
+            return json.load(f)
+    except:
+        print(f"Error occurred while loading JSON file from URL: {url}")
+        return {}
 
 def start(
     dev: bool = False,

--- a/neuron-viewer/python/server.py
+++ b/neuron-viewer/python/server.py
@@ -10,12 +10,8 @@ import json
 import urllib.request
 
 def load_az_json(url):
-    try:
-        with urllib.request.urlopen(url) as f:
-            return json.load(f)
-    except:
-        print(f"Error occurred while loading JSON file from URL: {url}")
-        return {}
+    with urllib.request.urlopen(url) as f:
+        return json.load(f)
 
 def start(
     dev: bool = False,


### PR DESCRIPTION
This MR fixes the authentication error for Azure mentioned in #1:


In [neuron-viewer/python/server.py](https://github.com/openai/automated-interpretability/blob/main/neuron-viewer/python/server.py#L10) file, blobfile is used to get the JSON from azure.

However, if you are not logged in to Azure it will throw:

  File "/opt/homebrew/lib/python3.10/site-packages/blobfile/_azure.py", line 797, in _get_access_token
    raise Error(msg)
blobfile._common.Error: Could not find any credentials that grant access to storage account: 'openaipublic' and container: 'neuron-explainer'
    Access Failure: message=Could not access container, request=<Request method=GET url=https://openaipublic.blob.core.windows.net/neuron-explainer params={'restype': 'container', 'comp': 'list', 'maxresults': '1'}>, status=404, error=ResourceNotFound, error_description=The specified resource does not exist.
RequestId:ea50e029-201e-00bf-04d4-82eb6a000000

It seems to be related to this issue https://github.com/christopher-hesse/blobfile/issues/118, and you have to login to azure to use this repository. If we use urllib we can solve this issue.

