### PR TITLE
Use correct api_client parameters for new simulator

### DIFF
--- a/neuron-explainer/neuron_explainer/explanations/simulator.py
+++ b/neuron-explainer/neuron_explainer/explanations/simulator.py
@@ -718,7 +718,7 @@ class LogprobFreeExplanationTokenSimulator(NeuronSimulator):
             self.explanation,
         )
         response = await self.api_client.make_request(
-            prompt=prompt, echo=False, max_tokens=1000
+            messages=prompt
         )
         assert len(response["choices"]) == 1
 


### PR DESCRIPTION
New simulator should use `messages` parameter instead of `prompt` to call the chat endpoint instead of the completion endpoint.

This also removes `echo` and `max_tokens`.