### PR TITLE
Add gpt-4-1106-preview (gpt4-turbo) to Valid Explainer Models

### DIFF
--- a/neuron-explainer/neuron_explainer/explanations/explainer.py
+++ b/neuron-explainer/neuron_explainer/explanations/explainer.py
@@ -62,7 +62,7 @@ class ContextSize(int, Enum):
         raise ValueError(f"{i} is not a valid ContextSize")
 
 
-HARMONY_V4_MODELS = ["gpt-3.5-turbo", "gpt-4"]
+HARMONY_V4_MODELS = ["gpt-3.5-turbo", "gpt-4", "gpt-4-1106-preview"]
 
 
 class NeuronExplainer(ABC):


### PR DESCRIPTION
Gpt4-turbo `gpt-4-1106-preview` is 3x cheaper and seems to work well: [see examples of its explanations](https://www.neuronpedia.org/gpt2-small/6-mlp-oai)

Adds the model to `HARMONY_V4_MODELS`.

Edit: force pushed to remove potential conflicts from unmerged branches